### PR TITLE
Fix: unset proxy environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,14 @@ FROM base AS runner
 ARG VERSION
 ENV VERSION=$VERSION
 
+# Unset proxy for use outside MCH
+ENV HTTP_PROXY= \
+   http_proxy= \
+   HTTPS_PROXY= \
+   https_proxy= \
+   NO_PROXY= \
+   no_proxy= 
+
 # Create a non-root user and set up permissions
 RUN useradd --create-home flexprep-user
 


### PR DESCRIPTION
## Purpose:
The base image provided by Meteoswiss defines environment variables that point to the Meteoswiss proxy. This causes issues when running the container outside of the Meteoswiss network (as is the case for this project). Therefore, the solution is to manually unset these environment variables in the Dockerfile to prevent connection problems.