### PR TITLE
Fix time arg to two digits and 00 added for the min.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV HTTP_PROXY= \
    HTTPS_PROXY= \
    https_proxy= \
    NO_PROXY= \
-   no_proxy= 
+   no_proxy=
 
 # Create a non-root user and set up permissions
 RUN useradd --create-home flexprep-user

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To set up the VM for this project, you need to manually add the following files 
 2. `.aviso/` **Folder:** This folder contains configuration and script files required for the AVISO system as described in the `aviso/README.md` file in this repository.
 
 3. `.aws/` **Folder:** This folder contains AWS credentials and configuration files used to authenticate with AWS services.
-    
+
       `credentials` **file:** Contains AWS access keys and secret keys.
 
            .. code-block:: ini
@@ -33,7 +33,7 @@ To set up the VM for this project, you need to manually add the following files 
               output = json
 
 4. `.env` **File:** This file contains environment variables including S3 bucket access keys and secret keys required by the application.
-  
+
        .. code-block:: bash
 
           S3_ACCESS_KEY=your-access-key

--- a/flexprep/__main__.py
+++ b/flexprep/__main__.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 def parse_arguments():
     """Parse and return command-line arguments."""
     parser = argparse.ArgumentParser(description="Parse metadata of new file received")
-    parser.add_argument("--step", type=int, required=True, help="Step argument")
+    parser.add_argument("--step", type=str, required=True, help="Step argument")
     parser.add_argument(
         "--date", type=str, required=True, help="Date argument (yyyymmdd)"
     )
@@ -28,8 +28,9 @@ def parse_arguments():
 def create_ifs_forecast_obj(args):
     """Create an IFSForecast object based on the parsed arguments."""
     try:
+
         # Combine date and time to create forecast_ref_time
-        forecast_ref_time_str = f"{args.date}{args.time:02d}00"
+        forecast_ref_time_str = f"{args.date}{int(args.time):02d}00"
         forecast_ref_time = dt.strptime(forecast_ref_time_str, "%Y%m%d%H%M")
         return IFSForecast(
             row_id=None,

--- a/flexprep/__main__.py
+++ b/flexprep/__main__.py
@@ -29,7 +29,7 @@ def create_ifs_forecast_obj(args):
     """Create an IFSForecast object based on the parsed arguments."""
     try:
         # Combine date and time to create forecast_ref_time
-        forecast_ref_time_str = f"{args.date}{args.time}"
+        forecast_ref_time_str = f"{args.date}{args.time:02d}00"
         forecast_ref_time = dt.strptime(forecast_ref_time_str, "%Y%m%d%H%M")
         return IFSForecast(
             row_id=None,

--- a/flexprep/__main__.py
+++ b/flexprep/__main__.py
@@ -35,7 +35,7 @@ def create_ifs_forecast_obj(args):
         return IFSForecast(
             row_id=None,
             forecast_ref_time=forecast_ref_time,
-            step=args.step,
+            step=int(args.step),
             key=Path(args.location).name,
             processed=False,
         )


### PR DESCRIPTION
## Purpose:

- `__main__.py` Fix: the model time of 12 UTC was originally provided as time="12", but when converted to a datetime using the %H%M format, it incorrectly resulted in 01:02:00. To resolve this, the time is now padded to two digits, with 00 added for the minutes. This approach is reliable since all model runs occur at round hours (e.g., every 6 hours).

- other files: pre-commit run