### PR TITLE
Fix writing the fields in GRIB to files

### DIFF
--- a/flexprep/domain/flexpart_utils.py
+++ b/flexprep/domain/flexpart_utils.py
@@ -42,12 +42,12 @@ def prepare_output(
     missing_const = (ds_in.keys() & constant_fields) - ds_out.keys()
 
     for field in ds_out:
-        ds_out[field] = ds_out[field].isel(lead_time=slice(-1, None)).squeeze()
+        ds_out[field] = ds_out[field].isel(lead_time=-1)
     for field in missing_fields:
         logger.warning(f"Field '{field}' not found in output")
-        ds_out[field] = ds_in[field].isel(lead_time=slice(-1, None)).squeeze()
+        ds_out[field] = ds_in[field].isel(lead_time=-1)
     for field in missing_const:
-        ds_out[field] = ds_in[field].squeeze()
+        ds_out[field] = ds_in[field]
 
     ds_out["etadot"] = ds_out.pop("omega")
     ds_out["cp"] = ds_out["cp"] * 1000

--- a/flexprep/domain/flexpart_utils.py
+++ b/flexprep/domain/flexpart_utils.py
@@ -50,5 +50,11 @@ def prepare_output(
         ds_out[field] = ds_in[field]
 
     ds_out["etadot"] = ds_out.pop("omega")
+
+    cp_attrs = ds_out["cp"].attrs.copy()
     ds_out["cp"] = ds_out["cp"] * 1000
+    ds_out["cp"] = ds_out["cp"].assign_attrs(cp_attrs)
+
+    lsp_attrs = ds_out["lsp"].attrs.copy()
     ds_out["lsp"] = ds_out["lsp"] * 100
+    ds_out["lsp"] = ds_out["lsp"].assign_attrs(lsp_attrs)

--- a/flexprep/domain/flexpart_utils.py
+++ b/flexprep/domain/flexpart_utils.py
@@ -51,10 +51,6 @@ def prepare_output(
 
     ds_out["etadot"] = ds_out.pop("omega")
 
-    cp_attrs = ds_out["cp"].attrs.copy()
-    ds_out["cp"] = ds_out["cp"] * 1000
-    ds_out["cp"] = ds_out["cp"].assign_attrs(cp_attrs)
+    ds_out["cp"] = (ds_out["cp"] * 1000).assign_attrs(ds_out["cp"].attrs)
 
-    lsp_attrs = ds_out["lsp"].attrs.copy()
-    ds_out["lsp"] = ds_out["lsp"] * 100
-    ds_out["lsp"] = ds_out["lsp"].assign_attrs(lsp_attrs)
+    ds_out["lsp"] = (ds_out["lsp"] * 100).assign_attrs(ds_out["lsp"].attrs)

--- a/flexprep/domain/processing.py
+++ b/flexprep/domain/processing.py
@@ -130,9 +130,8 @@ class Processing:
                 # Write data to the temporary file
                 with open(output_file.name, "wb") as fout:
                     for name, field in ds_out.items():
-                        if field.attrs.get("v_coord") == "hybrid":
-                            logger.info(f"Writing GRIB fields to {output_file.name}")
-                            grib_decoder.save(field, fout)
+                        logger.info(f"Writing GRIB field {name} to {output_file.name}")
+                        grib_decoder.save(field, fout)
 
                     # Upload the file to S3
                     S3client().upload_file(output_file.name, key=key)

--- a/flexprep/domain/processing.py
+++ b/flexprep/domain/processing.py
@@ -124,16 +124,16 @@ class Processing:
             key = f"output_dispf{forecast_ref_time_str}{step_to_process}"
 
             ref = next(
-                f
-                for f in ds_out.values()
-                if metadata.extract_keys(f.message, "editionNumber") == 2
+                field
+                for field in ds_out.values()
+                if metadata.extract_keys(field.message, "editionNumber") == 2
             )
 
             with tempfile.NamedTemporaryFile(
                 suffix=key, delete=False, mode="wb"
             ) as output_file:
                 for name, field in ds_out.items():
-                    if field.squeeze().isnull().all():
+                    if field.isnull().all():
                         logging.info(f"Ignoring field {field} - only NaN values")
                         continue
 

--- a/flexprep/domain/processing.py
+++ b/flexprep/domain/processing.py
@@ -123,14 +123,12 @@ class Processing:
         try:
             key = f"output_dispf{forecast_ref_time_str}{step_to_process}"
 
+            ref_keys = "editionNumber", "productDefinitionTemplateNumber"
+            ref_values = 2, 0
             ref = next(
                 field
                 for field in ds_out.values()
-                if metadata.extract_keys(field.message, "editionNumber") == 2
-                and metadata.extract_keys(
-                    field.message, "productDefinitionTemplateNumber"
-                )
-                == 0
+                if metadata.extract_keys(field.message, ref_keys) == ref_values
             )
 
             with tempfile.NamedTemporaryFile(

--- a/flexprep/domain/processing.py
+++ b/flexprep/domain/processing.py
@@ -122,7 +122,7 @@ class Processing:
         forecast_ref_time_str = forecast_ref_time.strftime("%Y%m%d%H%M")
 
         try:
-            key = f"output_dispf{forecast_ref_time_str}_step{step_to_process}"
+            key = f"output_dispf{forecast_ref_time_str}{step_to_process}"
 
             with tempfile.NamedTemporaryFile(
                 suffix=key,


### PR DESCRIPTION
- processing.py:  Fix writing grib1 and grib2 fields to file by removing the condition on the attribute that didn't exist and thus nothing was wirtten in the file. 
- flexpart_utils.py: Reassign the attributes to the dataarray which were lost when doing: `ds_out["cp"] = ds_out["cp"] * 1000` 