### PR TITLE
Fix Intput File Naming Convention for Flexpart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: check-ast
     -   id: check-case-conflict
@@ -42,6 +42,7 @@ repos:
         language: system
         entry: black
         types_or: [python, pyi]
+        args: ["--line-length=88"]
 -   repo: local
     hooks:
     -   id: isort

--- a/flexprep/config/settings.yaml
+++ b/flexprep/config/settings.yaml
@@ -16,5 +16,5 @@ main:
       endpoint_url: https://object-store.os-api.cci1.ecmwf.int
       name: flexprep-output
   time_settings:
-    tincr: 3
+    tincr: 1
     tstart: 0

--- a/flexprep/domain/processing.py
+++ b/flexprep/domain/processing.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import typing
 from datetime import datetime as dt
+from datetime import timedelta
 
 import meteodatalab.operators.flexpart as flx
 from meteodatalab import config, data_source, grib_decoder, metadata
@@ -121,10 +122,10 @@ class Processing:
         row_id: int,
     ) -> None:
         """Save processed data to a temporary file and upload to output-S3."""
-        forecast_ref_time_str = forecast_ref_time.strftime("%Y%m%d%H%M")
-
         try:
-            key = f"output_dispf{forecast_ref_time_str}{step_to_process}"
+            lead_time = forecast_ref_time + timedelta(hours=step_to_process)
+            lead_time_str = lead_time.strftime("%Y%m%d%H")
+            key = f"dispf{lead_time_str}"
 
             ref_keys = "editionNumber", "productDefinitionTemplateNumber"
             ref_values = 2, 0

--- a/flexprep/domain/validation_utils.py
+++ b/flexprep/domain/validation_utils.py
@@ -19,7 +19,8 @@ def validate_dataset(
     if not all(
         (
             np.array_equal(
-                array.coords["lead_time"].values, [pd.to_timedelta(0, "h").value]
+                array.coords["lead_time"].values,
+                [pd.to_timedelta(0, "h").value],
             )
         )
         or (

--- a/test/domain/test_validation_utils.py
+++ b/test/domain/test_validation_utils.py
@@ -49,7 +49,8 @@ def test_missing_param(setup_data):
     del ds["pressure"]
 
     with pytest.raises(
-        ValueError, match="Not all requested parameters are present in the dataset"
+        ValueError,
+        match="Not all requested parameters are present in the dataset",
     ):
         validate_dataset(ds, params, ref_time, step, prev_step)
 


### PR DESCRIPTION
## Purpose:
- `flexprep/domain/processing.py`: Address an issue with the input file naming convention expected by Flexpart. The required format for input files is now corrected to follow the naming convention of `dispf{lead_time}` for Flexprep output files.

- `flexprep/config/settings.yaml`: Change default time increment parameter between forecasts to 1 hour (Europe configuration)

- Other files: pre-commit