### PR TITLE
Standardize Condition for Identifying Constant Files Across Different Run Times

### DIFF
--- a/flexprep/domain/db_utils.py
+++ b/flexprep/domain/db_utils.py
@@ -174,9 +174,10 @@ class DB:
         LEFT JOIN
             uploaded prev ON cur.forecast_ref_time = prev.forecast_ref_time
                         AND prev.step = cur.step - ?
-                        -- Omit the constant file (stream 'S') to avoid duplicates,
-                        -- as it also has prev.step = 0
-                        AND (prev_step != 0 OR SUBSTRING(prev.key, 3, 1) = 'S')
+                        -- Skip constants file (key ends in '11')
+                        -- to avoid duplicate cur.step
+                        -- as constants file also has prev.step = 0
+                        AND (prev_step != 0 OR RIGHT(prev.key, 2) != '11')
 
         WHERE
             cur.forecast_ref_time = ? AND


### PR DESCRIPTION
## Purpose
Adjust the condition for constant files, as they are named differently across runs: in {00,12UTC}, the constant file is in stream D, with step 0 in stream S; in {06,18UTC}, both constant and step files use stream S. Thus, omitting the constant file based on stream won’t work. Instead, the constant file can be identified by its last two characters, '11', while forecast files end in '01'. Explanation of the streams and the runs here below:
![image](https://github.com/user-attachments/assets/d5698074-66a2-4f82-9ff3-3248416f01a8)
