### PR TITLE
Split events by domain in DB

### DIFF
--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -5,7 +5,7 @@ from datetime import datetime, UTC
 import boto3
 
 from flexpart_ifs_preprocessor import CONFIG
-from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile
+from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile, Feed
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,7 @@ def write_product_index(event: IFSForecastFile) -> None:
         'ReferenceTime': str(event.forecast_ref_time),
         'LeadTime': event.step,
         'FileName': event.filename,
+        'Domain': str(event.domain.value),
         'CreatedAt': creation_timestamp,
         'Status': 'PENDING',
     }
@@ -29,13 +30,18 @@ def write_product_index(event: IFSForecastFile) -> None:
     dynamodb_table.put_item(Item=message)
 
 
-def get_steps_to_process(forecast_ref_time: datetime) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
+def get_steps_to_process(forecast_ref_time: datetime, domain: Feed) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
 
     db_client = boto3.resource('dynamodb')
     dynamodb_table = db_client.Table(os.environ['DYNAMODB_TABLE'])
     all_response = dynamodb_table.query(
         KeyConditionExpression='ReferenceTimePartitionKey = :ref_time',
-        ExpressionAttributeValues={':ref_time': int(forecast_ref_time.timestamp())}
+        FilterExpression='#domain = :domain',
+        ExpressionAttributeNames={'#domain': 'Domain'},
+        ExpressionAttributeValues={
+            ':ref_time': int(forecast_ref_time.timestamp()),
+            ':domain': str(domain.value),
+        }
     )
     all_items = all_response.get('Items', [])
     items_by_lead_time = {item['LeadTime']: item for item in all_items}  # fast lookup
@@ -78,6 +84,7 @@ def dynamodb_item_to_ifs_forecast_file(item: dict) -> IFSForecastFile:
         step=item['LeadTime'],
         object_key=item['ObjectKey'],
         filename=item['FileName'],
+        domain=Feed(item['Domain']),
         processed=item['Status'] == 'PROCESSED'
     )
 

--- a/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
+++ b/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
@@ -27,7 +27,7 @@ def lambda_handler(event: ConsumerRecords, _: LambdaContext) -> None:
 
         write_product_index(file_event)
 
-        processable_steps, step_zero_files = get_steps_to_process(file_event.forecast_ref_time)
+        processable_steps, step_zero_files = get_steps_to_process(file_event.forecast_ref_time, file_event.domain)
         for file, prev_file in processable_steps:
             run_preprocessing(file, prev_file, step_zero_files)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexpart-ifs-preprocessor"
-version = "0.3.1"
+version = "0.3.2"
 description = "Preprocesses IFS data for use in Flexpart"
 license = "BSD-3-Clause"
 authors = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -131,6 +131,7 @@ def oper_dynamodb_table(mocked_aws):
             "ReferenceTime": str(OPER_REF_TIME),
             "LeadTime": step,
             "FileName": filename,
+            "Domain": "EUROPE",
             "CreatedAt": 0,
             "Status": "PENDING",
         })

--- a/test/domain/test_db_utils.py
+++ b/test/domain/test_db_utils.py
@@ -26,6 +26,7 @@ FORECAST_REF_TIME = datetime(2026, 3, 31, 6, 0, 0, tzinfo=timezone.utc)
 REF_TIME_KEY = int(FORECAST_REF_TIME.timestamp())
 
 _FILENAME_TEMPLATE = "s4y_f2_ifs-ens-cf_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
+_F1_FILENAME_TEMPLATE = "s4y_f1_ifs-hres_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
 
 def _make_file(step: int, processed: bool = False) -> IFSForecastFile:
     filename = _FILENAME_TEMPLATE.format(step=step)
@@ -58,6 +59,7 @@ def _put_items(table, items: list[tuple[int, str]]) -> None:
             "ReferenceTime": str(FORECAST_REF_TIME),
             "LeadTime": step,
             "FileName": filename,
+            "Domain": "EUROPE",
             "CreatedAt": 0,
             "Status": status,
         })
@@ -67,6 +69,21 @@ def _put_item(table, step: int, status: str = "PENDING") -> None:
     """Convenience wrapper for inserting a single item (no duplicate-step handling)."""
     _put_items(table, [(step, status)])
 
+
+def _put_domain_item(table, step: int, domain: Feed, status: str = "PENDING", prefix: str = "prefix") -> None:
+    """Insert a single item for the given domain using the appropriate filename template."""
+    template = _FILENAME_TEMPLATE if domain == Feed.F2 else _F1_FILENAME_TEMPLATE
+    filename = template.format(step=step)
+    table.put_item(Item={
+        "ReferenceTimePartitionKey": REF_TIME_KEY,
+        "ObjectKey": f"{prefix}/{filename}",
+        "ReferenceTime": str(FORECAST_REF_TIME),
+        "LeadTime": step,
+        "FileName": filename,
+        "Domain": domain.value,
+        "CreatedAt": 0,
+        "Status": status,
+    })
 
 
 @pytest.fixture
@@ -94,6 +111,7 @@ class TestDynamodbItemToIFSForecastFile:
             "ObjectKey": f"prefix/{filename}",
             "LeadTime": 6,
             "FileName": filename,
+            "Domain": "EUROPE",
             "Status": status,
         }
         f = dynamodb_item_to_ifs_forecast_file(item)
@@ -106,6 +124,7 @@ class TestDynamodbItemToIFSForecastFile:
             "ObjectKey": f"prefix/{filename}",
             "LeadTime": 6,
             "FileName": filename,
+            "Domain": "EUROPE",
             "Status": "PENDING",
         }
         f = dynamodb_item_to_ifs_forecast_file(item)
@@ -118,6 +137,7 @@ class TestDynamodbItemToIFSForecastFile:
             "ObjectKey": f"prefix/{filename}",
             "LeadTime": 12,
             "FileName": filename,
+            "Domain": "EUROPE",
             "Status": "PENDING",
         }
         f = dynamodb_item_to_ifs_forecast_file(item)
@@ -131,6 +151,7 @@ class TestDynamodbItemToIFSForecastFile:
             "ObjectKey": key,
             "LeadTime": 6,
             "FileName": filename,
+            "Domain": "EUROPE",
             "Status": "PENDING",
         }
         f = dynamodb_item_to_ifs_forecast_file(item)
@@ -170,7 +191,7 @@ class TestGetStepsToProcess:
         """Populate table with (step, status) items and call get_steps_to_process."""
         _put_items(table, items)
 
-        return get_steps_to_process(FORECAST_REF_TIME)
+        return get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
 
     def test_returns_empty_when_no_step_zero(self, ddb_table):
 
@@ -241,6 +262,51 @@ class TestGetStepsToProcess:
         statuses.append((0, "PROCESSED"))
         items_to_process, _ = self._run(ddb_table, statuses)
         assert len(items_to_process) == len(pending_steps)
+
+    def test_ignores_predecessor_from_different_domain(self, ddb_table):
+        """A PENDING F2 step=6 must not be queued when only an F1 step=3 exists.
+
+        The step=3 predecessor is present in DynamoDB but belongs to a different
+        domain (F1/GLOBAL).  The query must filter it out so that step=6 is not
+        treated as processable.
+        """
+        # Two F2 step=0 files satisfy the gate condition
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED", prefix="prefix2")
+        # Only F1 has step=3 – the F2 predecessor is missing
+        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status="PROCESSED")
+        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status="PENDING")
+
+        items_to_process, _ = get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
+
+        assert items_to_process == [], (
+            "step=6 should not be queued because its F2 predecessor (step=3) is absent"
+        )
+
+    def test_only_returns_items_for_requested_domain(self, ddb_table):
+        """Results must contain only items belonging to the requested domain.
+
+        When both F1 and F2 items are present for the same reference time,
+        querying for F2 must return step-zero files and processable pairs
+        exclusively from F2.
+        """
+        # F2: full chain – two step=0, step=3 PROCESSED, step=6 PENDING
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED", prefix="prefix2")
+        _put_domain_item(ddb_table, step=3, domain=Feed.F2, status="PROCESSED")
+        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status="PENDING")
+        # F1: also has items in the same table
+        _put_domain_item(ddb_table, step=0, domain=Feed.F1, status="PROCESSED", prefix="f1prefix")
+        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status="PROCESSED", prefix="f1prefix")
+
+        items_to_process, zeros = get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
+
+        assert all(z.domain == Feed.F2 for z in zeros), "step-zero list must contain only F2 items"
+        assert len(zeros) == 2
+        assert len(items_to_process) == 1
+        current, prev = items_to_process[0]
+        assert current.domain == Feed.F2
+        assert prev.domain == Feed.F2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
get_steps_to_process queried DynamoDB for all items matching the reference time. This meant a step from domain F1 could be incorrectly used as a predecessor when processing domain F2 files (and vice versa), leading to wrong processing pairs or items being queued with a cross-domain predecessor.

