### PR TITLE
Support nested Europe domain for Global Flexpart IFS runs

### DIFF
--- a/flexpart_ifs_preprocessor/config/settings.py
+++ b/flexpart_ifs_preprocessor/config/settings.py
@@ -17,12 +17,6 @@ class TimeSettings(BaseModel):
     tincr: int
     tstart: int
 
-class AppSettings(BaseModel):
-    model_config = ConfigDict(validate_assignment=True)
-    s3: Buckets
-    time_settings: TimeSettings
-
 class JobSettings(BaseServiceSettings):
     logging: LoggingSettings
     app_name: str
-    main: AppSettings

--- a/flexpart_ifs_preprocessor/config/settings.py
+++ b/flexpart_ifs_preprocessor/config/settings.py
@@ -4,19 +4,16 @@ from mchpy.audit.logger import LoggingSettings
 from mchpy.config.base_settings import BaseServiceSettings
 
 
-class Bucket(BaseModel):
-    endpoint_url: str
-    name: str
+class AppSettings(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+    source_role_arn: str
+    source_s3_bucket_arn: str
+    target_s3_bucket_name_europe: str
+    target_s3_bucket_name_global: str
+    dynamodb_table_name: str
 
-
-class Buckets(BaseModel):
-    output: Bucket
-
-
-class TimeSettings(BaseModel):
-    tincr: int
-    tstart: int
 
 class JobSettings(BaseServiceSettings):
     logging: LoggingSettings
     app_name: str
+    main: AppSettings

--- a/flexpart_ifs_preprocessor/config/settings.yaml
+++ b/flexpart_ifs_preprocessor/config/settings.yaml
@@ -6,3 +6,9 @@ logging:
   child_log_levels:
     mchpy: INFO
 app_name: Flexpart IFS Preprocessor
+main:
+  source_role_arn: SOURCE_ROLE_ARN
+  source_s3_bucket_arn: SOURCE_S3_BUCKET_ARN
+  target_s3_bucket_name_europe: target-bucket-europe
+  target_s3_bucket_name_global: target-bucket-global
+  dynamodb_table_name: db-table

--- a/flexpart_ifs_preprocessor/config/settings.yaml
+++ b/flexpart_ifs_preprocessor/config/settings.yaml
@@ -5,12 +5,4 @@ logging:
   formatter: "standard"
   child_log_levels:
     mchpy: INFO
-app_name: Flexpart-IFS-Preprocessor
-main:
-  s3:
-    output:
-      endpoint_url: https://object-store.os-api.cci1.ecmwf.int
-      name: flexpart-input
-  time_settings:
-    tincr: 3
-    tstart: 0
+app_name: Flexpart IFS Preprocessor

--- a/flexpart_ifs_preprocessor/domain/data_model.py
+++ b/flexpart_ifs_preprocessor/domain/data_model.py
@@ -25,7 +25,6 @@ class IFSForecastFile:
     def __init__(self, object_key: str, filename: str, domain: Feed | None = None, forecast_ref_time: datetime | None = None, step: int | None = None, processed: bool = False) -> None:
         self.object_key = object_key
         self.filename = filename
-        self.processed = processed
         self.forecast_ref_time: datetime = forecast_ref_time or self._extract_datetime()
         self.step: int = int(step) if step is not None else self._extract_lead_time()
         self.domain = domain or self._extract_feed()

--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -5,6 +5,7 @@ from datetime import datetime, UTC
 import boto3
 
 from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile, Feed
+from flexpart_ifs_preprocessor import CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ def write_product_index(event: IFSForecastFile) -> None:
         message['Status_3h'] = 'N/A'
 
     db_client = boto3.resource('dynamodb')
-    dynamodb_table = db_client.Table(os.environ['DYNAMODB_TABLE'])
+    dynamodb_table = db_client.Table(CONFIG.main.dynamodb_table_name)
     dynamodb_table.put_item(Item=message)
 
 
@@ -44,7 +45,7 @@ def get_steps_to_process(forecast_ref_time: datetime, domain: Feed, tincr: int =
     along with a list of step=0 files."""
 
     db_client = boto3.resource('dynamodb')
-    dynamodb_table = db_client.Table(os.environ['DYNAMODB_TABLE'])
+    dynamodb_table = db_client.Table(CONFIG.main.dynamodb_table_name)
     all_response = dynamodb_table.query(
         KeyConditionExpression='ReferenceTimePartitionKey = :ref_time',
         FilterExpression='#domain = :domain',
@@ -102,7 +103,7 @@ def update_product_index_processed(object_key: str, reference_time: datetime, ti
     processed_timestamp = int(datetime.now(UTC).timestamp())
 
     db_client = boto3.resource('dynamodb')
-    dynamodb_table = db_client.Table(os.environ['DYNAMODB_TABLE'])
+    dynamodb_table = db_client.Table(CONFIG.main.dynamodb_table_name)
     dynamodb_table.update_item(
         Key={
             'ReferenceTimePartitionKey': int(reference_time.timestamp()),

--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -4,13 +4,13 @@ from datetime import datetime, UTC
 
 import boto3
 
-from flexpart_ifs_preprocessor import CONFIG
 from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile
 
 logger = logging.getLogger(__name__)
 
 
 def write_product_index(event: IFSForecastFile) -> None:
+    """Write a new entry to the DynamoDB product index for the given file event."""
 
     # Adding created_at parameter for tracking files longevity
     creation_timestamp = int(datetime.now(UTC).timestamp())
@@ -22,14 +22,25 @@ def write_product_index(event: IFSForecastFile) -> None:
         'LeadTime': event.step,
         'FileName': event.filename,
         'CreatedAt': creation_timestamp,
-        'Status': 'PENDING',
+        f'Status_3h': 'PENDING',
+        f'Status_1h': 'PENDING',
     }
+    if event.domain == 'F1':
+        # For F1 (GLOBAL) files, only 3-hourly preprocessing is needed, so we can set the 1-hourly status to 'N/A'.
+        message['Status_1h'] = 'N/A'
+    elif event.domain == 'F2' and event.step % 3 != 0:
+        # For F2 (EUROPE) files that are not on 3-hourly steps, only 1-hourly preprocessing is needed, so we can set the 3-hourly status to 'N/A'.
+        message['Status_3h'] = 'N/A'
+
     db_client = boto3.resource('dynamodb')
     dynamodb_table = db_client.Table(os.environ['DYNAMODB_TABLE'])
     dynamodb_table.put_item(Item=message)
 
 
-def get_steps_to_process(forecast_ref_time: datetime) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
+def get_steps_to_process(forecast_ref_time: datetime, tincr: int) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
+    """Query the DynamoDB product index for the given forecast reference time
+    and return a list of (file, previous_file) tuples to process,
+    along with a list of step=0 files."""
 
     db_client = boto3.resource('dynamodb')
     dynamodb_table = db_client.Table(os.environ['DYNAMODB_TABLE'])
@@ -39,7 +50,7 @@ def get_steps_to_process(forecast_ref_time: datetime) -> tuple[list[tuple[IFSFor
     )
     all_items = all_response.get('Items', [])
     items_by_lead_time = {item['LeadTime']: item for item in all_items}  # fast lookup
-    pending_items = [item for item in all_items if item['Status'] == 'PENDING']
+    pending_items = [item for item in all_items if item[f'Status_{tincr}h'] == 'PENDING']
     step_zero_items = [dynamodb_item_to_ifs_forecast_file(item) for item in all_items if item['LeadTime'] == 0]
 
     items_to_process = []
@@ -55,7 +66,7 @@ def get_steps_to_process(forecast_ref_time: datetime) -> tuple[list[tuple[IFSFor
 
     for item in pending_items:
         lead_time = item['LeadTime']
-        prev_lead_time = lead_time - CONFIG.main.time_settings.tincr
+        prev_lead_time = lead_time - tincr
 
         logger.debug(f"Unprocessed item: ObjectKey={item['ObjectKey']}, LeadTime={item['LeadTime']}, CreatedAt={item['CreatedAt']}")
 
@@ -77,11 +88,10 @@ def dynamodb_item_to_ifs_forecast_file(item: dict) -> IFSForecastFile:
         forecast_ref_time=datetime.fromtimestamp(int(item['ReferenceTimePartitionKey']), tz=UTC),
         step=item['LeadTime'],
         object_key=item['ObjectKey'],
-        filename=item['FileName'],
-        processed=item['Status'] == 'PROCESSED'
+        filename=item['FileName']
     )
 
-def update_product_index_processed(object_key: str, reference_time: datetime) -> None:
+def update_product_index_processed(object_key: str, reference_time: datetime, tincr: int) -> None:
     processed_timestamp = int(datetime.now(UTC).timestamp())
 
     db_client = boto3.resource('dynamodb')
@@ -91,10 +101,7 @@ def update_product_index_processed(object_key: str, reference_time: datetime) ->
             'ReferenceTimePartitionKey': int(reference_time.timestamp()),
             'ObjectKey': object_key,
         },
-        UpdateExpression='SET ProcessedAt = :processed_at, #s = :status',
-        ExpressionAttributeNames={
-            '#s': 'Status',  # 'Status' is a reserved word in DynamoDB
-        },
+        UpdateExpression=f'SET ProcessedAt = :processed_at, Status_{tincr}h = :status',
         ExpressionAttributeValues={
             ':processed_at': processed_timestamp,
             ':status': 'PROCESSED',

--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -38,7 +38,7 @@ def write_product_index(event: IFSForecastFile) -> None:
     dynamodb_table.put_item(Item=message)
 
 
-def get_steps_to_process(forecast_ref_time: datetime, domain: Feed, tincr: int) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
+def get_steps_to_process(forecast_ref_time: datetime, domain: Feed, tincr: int = 1) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
     """Query the DynamoDB product index for the given forecast reference time
     and return a list of (file, previous_file) tuples to process,
     along with a list of step=0 files."""
@@ -98,7 +98,7 @@ def dynamodb_item_to_ifs_forecast_file(item: dict) -> IFSForecastFile:
         domain=Feed(item['Domain'])
     )
 
-def update_product_index_processed(object_key: str, reference_time: datetime, tincr: int) -> None:
+def update_product_index_processed(object_key: str, reference_time: datetime, tincr: int = 1) -> None:
     processed_timestamp = int(datetime.now(UTC).timestamp())
 
     db_client = boto3.resource('dynamodb')

--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -4,7 +4,7 @@ from datetime import datetime, UTC
 
 import boto3
 
-from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile
+from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile, Feed
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,7 @@ def write_product_index(event: IFSForecastFile) -> None:
         'ReferenceTime': str(event.forecast_ref_time),
         'LeadTime': event.step,
         'FileName': event.filename,
+        'Domain': str(event.domain.value),
         'CreatedAt': creation_timestamp,
         f'Status_3h': 'PENDING',
         f'Status_1h': 'PENDING',
@@ -37,7 +38,7 @@ def write_product_index(event: IFSForecastFile) -> None:
     dynamodb_table.put_item(Item=message)
 
 
-def get_steps_to_process(forecast_ref_time: datetime, tincr: int) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
+def get_steps_to_process(forecast_ref_time: datetime, domain: Feed, tincr: int) -> tuple[list[tuple[IFSForecastFile, IFSForecastFile]], list[IFSForecastFile]]:
     """Query the DynamoDB product index for the given forecast reference time
     and return a list of (file, previous_file) tuples to process,
     along with a list of step=0 files."""
@@ -46,7 +47,12 @@ def get_steps_to_process(forecast_ref_time: datetime, tincr: int) -> tuple[list[
     dynamodb_table = db_client.Table(os.environ['DYNAMODB_TABLE'])
     all_response = dynamodb_table.query(
         KeyConditionExpression='ReferenceTimePartitionKey = :ref_time',
-        ExpressionAttributeValues={':ref_time': int(forecast_ref_time.timestamp())}
+        FilterExpression='#domain = :domain',
+        ExpressionAttributeNames={'#domain': 'Domain'},
+        ExpressionAttributeValues={
+            ':ref_time': int(forecast_ref_time.timestamp()),
+            ':domain': str(domain.value),
+        }
     )
     all_items = all_response.get('Items', [])
     items_by_lead_time = {item['LeadTime']: item for item in all_items}  # fast lookup
@@ -88,7 +94,8 @@ def dynamodb_item_to_ifs_forecast_file(item: dict) -> IFSForecastFile:
         forecast_ref_time=datetime.fromtimestamp(int(item['ReferenceTimePartitionKey']), tz=UTC),
         step=item['LeadTime'],
         object_key=item['ObjectKey'],
-        filename=item['FileName']
+        filename=item['FileName'],
+        domain=Feed(item['Domain'])
     )
 
 def update_product_index_processed(object_key: str, reference_time: datetime, tincr: int) -> None:

--- a/flexpart_ifs_preprocessor/domain/processing.py
+++ b/flexpart_ifs_preprocessor/domain/processing.py
@@ -52,18 +52,16 @@ def _generate_and_upload_grib_file(output_dir: Path,
 
     logger.info("Writing GRIB2 file to %s ...", output_dir)
 
-    if input_file.domain == Feed.F1:
-        prefix = "dispc"
-        bucket = os.environ['TARGET_S3_BUCKET_NAME_GLOBAL']
-    elif input_file.domain == Feed.F2 and tincr == 3:
-        prefix = "dispf"
-        bucket = os.environ['TARGET_S3_BUCKET_NAME_GLOBAL']
-    elif input_file.domain == Feed.F2 and tincr == 1:
-        prefix = "dispf"
-        bucket = os.environ['TARGET_S3_BUCKET_NAME_EUROPE']
-    else:
-        logger.error("Unknown feed/domain: %s", input_file.domain)
-        raise ValueError(f"Unknown feed/domain: {input_file.domain}")
+    _UPLOAD_CONFIG: dict[tuple[Feed, int], tuple[str, str]] = {
+        (Feed.F1, 3):    ("dispc", os.environ["TARGET_S3_BUCKET_NAME_GLOBAL"]),
+        (Feed.F2, 3):    ("dispf", os.environ["TARGET_S3_BUCKET_NAME_GLOBAL"]),
+        (Feed.F2, 1):    ("dispf", os.environ["TARGET_S3_BUCKET_NAME_EUROPE"]),
+    }
+
+    config = _UPLOAD_CONFIG.get((input_file.domain, tincr))
+    if config is None:
+        raise ValueError(f"Unknown feed/domain combination: {input_file.domain=}, {tincr=}")
+    prefix, bucket = config
 
     paths = write_grib(
         processed,

--- a/flexpart_ifs_preprocessor/domain/processing.py
+++ b/flexpart_ifs_preprocessor/domain/processing.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def run_preprocessing(input_file: IFSForecastFile,
                       previous_file: IFSForecastFile,
                       step_zero_files: list[IFSForecastFile],
-                      tincr: int) -> None:
+                      tincr: int = 1) -> None:
     # Download the files, skipping any that already exist in the temp directory
     logger.info("Downloading main file for processing: %s", input_file.object_key)
     with _download_temp_files([input_file, previous_file] + step_zero_files) as directory:
@@ -47,7 +47,7 @@ def run_preprocessing(input_file: IFSForecastFile,
 def _generate_and_upload_grib_file(output_dir: Path,
                                    processed: dict[str, DataArray],
                                    input_file: IFSForecastFile,
-                                   tincr: int) -> None:
+                                   tincr: int = 1) -> None:
     """Write FLEXPART-ready GRIB2 (one file per forecast step)"""
 
     logger.info("Writing GRIB2 file to %s ...", output_dir)
@@ -56,6 +56,9 @@ def _generate_and_upload_grib_file(output_dir: Path,
         prefix = "dispc"
         bucket = os.environ['TARGET_S3_BUCKET_NAME_GLOBAL']
     elif input_file.domain == Feed.F2 and tincr == 3:
+        prefix = "dispf"
+        bucket = os.environ['TARGET_S3_BUCKET_NAME_GLOBAL']
+    elif input_file.domain == Feed.F2 and tincr == 1:
         prefix = "dispf"
         bucket = os.environ['TARGET_S3_BUCKET_NAME_EUROPE']
     else:

--- a/flexpart_ifs_preprocessor/domain/processing.py
+++ b/flexpart_ifs_preprocessor/domain/processing.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 def run_preprocessing(input_file: IFSForecastFile,
                       previous_file: IFSForecastFile,
-                      step_zero_files: list[IFSForecastFile]) -> None:
+                      step_zero_files: list[IFSForecastFile],
+                      tincr: int) -> None:
     # Download the files, skipping any that already exist in the temp directory
     logger.info("Downloading main file for processing: %s", input_file.object_key)
     with _download_temp_files([input_file, previous_file] + step_zero_files) as directory:
@@ -40,10 +41,13 @@ def run_preprocessing(input_file: IFSForecastFile,
         processed = preprocess(raw)
         logger.info("Prepared fields: %s", ", ".join(sorted(processed.keys())))
 
-        _generate_and_upload_grib_file(directory, processed, input_file)
+        _generate_and_upload_grib_file(directory, processed, input_file, tincr)
 
 
-def _generate_and_upload_grib_file(output_dir: Path, processed: dict[str, DataArray], input_file: IFSForecastFile):
+def _generate_and_upload_grib_file(output_dir: Path,
+                                   processed: dict[str, DataArray],
+                                   input_file: IFSForecastFile,
+                                   tincr: int) -> None:
     """Write FLEXPART-ready GRIB2 (one file per forecast step)"""
 
     logger.info("Writing GRIB2 file to %s ...", output_dir)
@@ -51,7 +55,7 @@ def _generate_and_upload_grib_file(output_dir: Path, processed: dict[str, DataAr
     if input_file.domain == Feed.F1:
         prefix = "dispc"
         bucket = os.environ['TARGET_S3_BUCKET_NAME_GLOBAL']
-    elif input_file.domain == Feed.F2:
+    elif input_file.domain == Feed.F2 and tincr == 3:
         prefix = "dispf"
         bucket = os.environ['TARGET_S3_BUCKET_NAME_EUROPE']
     else:

--- a/flexpart_ifs_preprocessor/domain/processing.py
+++ b/flexpart_ifs_preprocessor/domain/processing.py
@@ -8,10 +8,12 @@ from typing import Any, Generator
 from flexprep.io_grib import write_grib
 from flexprep.preprocessing import preprocess
 from flexprep.sources.local import load_grib
+from xarray import DataArray
 
 from flexpart_ifs_preprocessor.domain.s3_utils import download_file, upload_to_s3
 from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile, Feed
-from xarray import DataArray
+from flexpart_ifs_preprocessor import CONFIG
+
 
 logger = logging.getLogger(__name__)
 
@@ -53,9 +55,9 @@ def _generate_and_upload_grib_file(output_dir: Path,
     logger.info("Writing GRIB2 file to %s ...", output_dir)
 
     _UPLOAD_CONFIG: dict[tuple[Feed, int], tuple[str, str]] = {
-        (Feed.F1, 3):    ("dispc", os.environ["TARGET_S3_BUCKET_NAME_GLOBAL"]),
-        (Feed.F2, 3):    ("dispf", os.environ["TARGET_S3_BUCKET_NAME_GLOBAL"]),
-        (Feed.F2, 1):    ("dispf", os.environ["TARGET_S3_BUCKET_NAME_EUROPE"]),
+        (Feed.F1, 3):    ("dispc", CONFIG.main.target_s3_bucket_name_global),
+        (Feed.F2, 3):    ("dispf", CONFIG.main.target_s3_bucket_name_global),
+        (Feed.F2, 1):    ("dispf", CONFIG.main.target_s3_bucket_name_europe),
     }
 
     config = _UPLOAD_CONFIG.get((input_file.domain, tincr))

--- a/flexpart_ifs_preprocessor/domain/s3_utils.py
+++ b/flexpart_ifs_preprocessor/domain/s3_utils.py
@@ -7,13 +7,14 @@ import json
 import boto3
 
 from flexpart_ifs_preprocessor.domain.data_model import  IFSForecastFile
+from flexpart_ifs_preprocessor import CONFIG
 
 logger = logging.getLogger(__name__)
 
 def download_file(file: IFSForecastFile, target_dir: Path) -> None:
     sts_client = boto3.client('sts')
     assumed_role = sts_client.assume_role(
-        RoleArn=os.environ['SOURCE_ROLE_ARN'],
+        RoleArn=CONFIG.main.source_role_arn,
         RoleSessionName=f'product_publisher_{str(uuid.uuid4())}' # TODO check this RoleSessionName
     )
     credentials = assumed_role['Credentials']
@@ -34,7 +35,7 @@ def download_file(file: IFSForecastFile, target_dir: Path) -> None:
 
     # download the file from S3 bucket
     target_s3_client.download_file(
-        os.environ['SOURCE_S3_BUCKET_ARN'],
+        CONFIG.main.source_s3_bucket_arn,
         file.object_key,
         target_path
     )

--- a/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
+++ b/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import base64
-import re
 from typing import Any
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -27,11 +26,28 @@ def lambda_handler(event: ConsumerRecords, _: LambdaContext) -> None:
 
         write_product_index(file_event)
 
-        processable_steps, step_zero_files = get_steps_to_process(file_event.forecast_ref_time)
-        for file, prev_file in processable_steps:
-            run_preprocessing(file, prev_file, step_zero_files)
+        # For F1 (GLOBAL) files, only 3-hourly preprocessing is needed, as FLEXPART
+        # global runs use 3-hourly NWP data with precipitation averaged over 3 hours.
+        #
+        # For F2 (EUROPE) files, preprocessing is run twice:
+        # - 1-hourly: for the FLEXPART-IFS-EUROPE domain (high-resolution regional runs)
+        # - 3-hourly: for nesting the Europe domain into the global runs, which requires
+        #   3-hourly NWP data with aggregated values (e.g. precipitation, fluxes) averaged
+        #   over 3 hours.
+        if file_event.domain == Feed.F1:
+            tincr_list = [3]
+        elif file_event.domain == Feed.F2 and file_event.step % 3 == 0:
+            tincr_list = [1,3]
+        elif file_event.domain == Feed.F2:
+            tincr_list = [1]
 
-            update_product_index_processed(file.object_key, file.forecast_ref_time)
+        for tincr in tincr_list:
+
+            processable_steps, step_zero_files = get_steps_to_process(file_event.forecast_ref_time, tincr)
+            for file, prev_file in processable_steps:
+                run_preprocessing(file, prev_file, step_zero_files, tincr)
+
+                update_product_index_processed(file.object_key, file.forecast_ref_time, tincr)
 
 
 def _kafka_event_to_input_data_aggregator_event(kafka_event: dict[str, Any]) -> InputDataAggregatorEvent:

--- a/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
+++ b/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
@@ -43,7 +43,7 @@ def lambda_handler(event: ConsumerRecords, _: LambdaContext) -> None:
 
         for tincr in tincr_list:
 
-            processable_steps, step_zero_files = get_steps_to_process(file_event.forecast_ref_time, tincr)
+            processable_steps, step_zero_files = get_steps_to_process(file_event.forecast_ref_time, file_event.domain, tincr)
             for file, prev_file in processable_steps:
                 run_preprocessing(file, prev_file, step_zero_files, tincr)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexpart-ifs-preprocessor"
-version = "0.4.0
+version = "0.4.0"
 description = "Preprocesses IFS data for use in Flexpart"
 license = "BSD-3-Clause"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexpart-ifs-preprocessor"
-version = "0.3.1"
+version = "0.3.2"
 description = "Preprocesses IFS data for use in Flexpart"
 license = "BSD-3-Clause"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexpart-ifs-preprocessor"
-version = "0.3.2"
+version = "0.4.0
 description = "Preprocesses IFS data for use in Flexpart"
 license = "BSD-3-Clause"
 authors = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -133,7 +133,8 @@ def oper_dynamodb_table(mocked_aws):
             "FileName": filename,
             "Domain": "EUROPE",
             "CreatedAt": 0,
-            "Status": "PENDING",
+            "Status_1h": "PENDING",
+            "Status_3h": "PENDING"
         })
     yield table
 
@@ -162,19 +163,6 @@ def oper_s3_buckets(mocked_aws):
 
 
 @pytest.fixture()
-def mocked_db_config(oper_dynamodb_table):
-    """Patch db_client to use the moto DynamoDB backend and set tincr=1.
-
-    Depends on ``oper_dynamodb_table`` to ensure the table exists before the
-    application code tries to query it, and to obtain a DynamoDB resource
-    that points at the same moto backend.
-    """
-    with patch("flexpart_ifs_preprocessor.domain.db_utils.CONFIG") as mock_cfg:
-        mock_cfg.main.time_settings.tincr = 1
-        yield
-
-
-@pytest.fixture()
-def aws_4h_environment(oper_dynamodb_table, oper_s3_buckets, mocked_db_config):
+def aws_4h_environment(oper_dynamodb_table, oper_s3_buckets):
     """Compose the three 4h scenario fixtures into a single environment handle."""
     yield Step4Test(table=oper_dynamodb_table, s3=oper_s3_buckets)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,19 +9,35 @@ import boto3
 import pytest
 from moto import mock_aws
 
+from flexpart_ifs_preprocessor.config.settings import AppSettings
+
 
 @pytest.fixture(autouse=True)
 def set_test_env_vars(monkeypatch):
-    monkeypatch.setenv("MAIN__DYNAMODB_TABLE_NAME", "test-table")
-    monkeypatch.setenv("MAIN__SOURCE_ROLE_ARN", "arn:aws:iam::123456789012:role/test-role")
-    monkeypatch.setenv("MAIN__SOURCE_S3_BUCKET_ARN", "source-bucket")
-    monkeypatch.setenv("MAIN__TARGET_S3_BUCKET_NAME_GLOBAL", "target-bucket-global")
-    monkeypatch.setenv("MAIN__TARGET_S3_BUCKET_NAME_EUROPE", "target-bucket-europe")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+
+
+OPER_TARGET_BUCKET_GLOBAL = "target-bucket-global"
+OPER_TARGET_BUCKET_EU = "target-bucket-europe"
+DYNAMODB_TABLE_NAME = "test-table"
+
+APP_SETTINGS = AppSettings(
+    dynamodb_table_name=DYNAMODB_TABLE_NAME,
+    source_role_arn="arn:aws:iam::123456789012:role/test-role",
+    source_s3_bucket_arn="source-bucket",
+    target_s3_bucket_name_global=OPER_TARGET_BUCKET_GLOBAL,
+    target_s3_bucket_name_europe=OPER_TARGET_BUCKET_EU
+)
+
+@pytest.fixture(autouse=True)
+def patch_config(monkeypatch):
+    """Patch the module-level CONFIG.main with the test AppSettings instance."""
+    from flexpart_ifs_preprocessor import CONFIG
+    monkeypatch.setattr(CONFIG, "main", APP_SETTINGS)
 
 
 RESOURCES_DIR = Path(__file__).parent / "resources"
@@ -33,14 +49,6 @@ RESOURCES_DIR = Path(__file__).parent / "resources"
 
 F2_FILENAME = "s4y_f2_ifs-ens-cf_od_scda_fc_20260331T060000Z_20260403T080000Z_74h"
 OBJECT_KEY = "some/prefix/" + F2_FILENAME
-
-
-# ---------------------------------------------------------------------------
-# DynamoDB table
-# ---------------------------------------------------------------------------
-
-DYNAMODB_TABLE_NAME = "test-table"
-
 
 # ---------------------------------------------------------------------------
 # Kafka / Lambda event helpers
@@ -64,8 +72,6 @@ OPER_REF_TIME    = datetime(2026, 4, 8, 0, 0, 0, tzinfo=timezone.utc)
 OPER_REF_TIME_TS = int(OPER_REF_TIME.timestamp())
 OPER_PREFIX      = "raw/s4y_f2/data"
 OPER_SOURCE_BUCKET = "source-bucket"
-OPER_TARGET_BUCKET_GLOBAL = "target-bucket-global"
-OPER_TARGET_BUCKET_EU = "target-bucket-europe"
 
 OPER_DA_0H  = "s4y_f2_ifs-da_od_oper_an_20260408T000000Z_20260408T000000Z_0h"
 OPER_ENS_0H = "s4y_f2_ifs-ens-cf_od_oper_fc_20260408T000000Z_20260408T000000Z_0h"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,11 +12,11 @@ from moto import mock_aws
 
 @pytest.fixture(autouse=True)
 def set_test_env_vars(monkeypatch):
-    monkeypatch.setenv("DYNAMODB_TABLE", "test-table")
-    monkeypatch.setenv("SOURCE_ROLE_ARN", "arn:aws:iam::123456789012:role/test-role")
-    monkeypatch.setenv("SOURCE_S3_BUCKET_ARN", "source-bucket")
-    monkeypatch.setenv("TARGET_S3_BUCKET_NAME_GLOBAL", "target-bucket-global")
-    monkeypatch.setenv("TARGET_S3_BUCKET_NAME_EUROPE", "target-bucket-europe")
+    monkeypatch.setenv("MAIN__DYNAMODB_TABLE_NAME", "test-table")
+    monkeypatch.setenv("MAIN__SOURCE_ROLE_ARN", "arn:aws:iam::123456789012:role/test-role")
+    monkeypatch.setenv("MAIN__SOURCE_S3_BUCKET_ARN", "source-bucket")
+    monkeypatch.setenv("MAIN__TARGET_S3_BUCKET_NAME_GLOBAL", "target-bucket-global")
+    monkeypatch.setenv("MAIN__TARGET_S3_BUCKET_NAME_EUROPE", "target-bucket-europe")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
@@ -84,7 +84,7 @@ def _kafka_event(filename: str, prefix: str = OPER_PREFIX) -> dict:
 
 
 @dataclass
-class Step4Test:
+class IntegrationTest:
     """Holds live moto AWS handles for the 4h processing integration scenario."""
     table: object  # boto3 Table resource for the test DynamoDB table
     s3: object     # boto3 S3 client
@@ -117,16 +117,54 @@ def _make_ddb_table(ddb):
 
 
 @pytest.fixture(scope="function")
-def oper_dynamodb_table(mocked_aws):
+def oper_dynamodb_table_4h(mocked_aws, request):
     """Create and pre-populate the DynamoDB table for the 4h scenario.
 
     Inserts PENDING entries for DA-0h, ENS-0h and ENS-3h (the prerequisites
     that must already exist before the 4h file arrives).
     """
+
+    entries = [
+        (OPER_DA_0H, 0),
+        (OPER_ENS_0H, 0),
+        (OPER_ENS_3H, 3),
+    ]
+
     ddb = boto3.resource("dynamodb", region_name="eu-central-1")
     table = _make_ddb_table(ddb)
     table.meta.client.get_waiter("table_exists").wait(TableName=DYNAMODB_TABLE_NAME)
-    for filename, step in [(OPER_DA_0H, 0), (OPER_ENS_0H, 0), (OPER_ENS_2H, 2), (OPER_ENS_3H, 3)]:
+    for filename, step in entries:
+        table.put_item(Item={
+            "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
+            "ObjectKey": f"{OPER_PREFIX}/{filename}",
+            "ReferenceTime": str(OPER_REF_TIME),
+            "LeadTime": step,
+            "FileName": filename,
+            "Domain": "EUROPE",
+            "CreatedAt": 0,
+            "Status_1h": "PENDING",
+            "Status_3h": "PENDING"
+        })
+    yield table
+
+@pytest.fixture(scope="function")
+def oper_dynamodb_table_3h(mocked_aws, request):
+    """Create and pre-populate the DynamoDB table for the 4h scenario.
+
+    Inserts PENDING entries for DA-0h, ENS-0h, ENS-2h, (the prerequisites
+    that must already exist before the 3h file arrives).
+    """
+
+    entries = [
+        (OPER_DA_0H, 0),
+        (OPER_ENS_0H, 0),
+        (OPER_ENS_2H, 2),
+    ]
+
+    ddb = boto3.resource("dynamodb", region_name="eu-central-1")
+    table = _make_ddb_table(ddb)
+    table.meta.client.get_waiter("table_exists").wait(TableName=DYNAMODB_TABLE_NAME)
+    for filename, step in entries:
         table.put_item(Item={
             "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
             "ObjectKey": f"{OPER_PREFIX}/{filename}",
@@ -165,6 +203,11 @@ def oper_s3_buckets(mocked_aws):
 
 
 @pytest.fixture()
-def aws_environment(oper_dynamodb_table, oper_s3_buckets):
-    """Compose the three 4h scenario fixtures into a single environment handle."""
-    yield Step4Test(table=oper_dynamodb_table, s3=oper_s3_buckets)
+def aws_environment_3h(oper_dynamodb_table_3h, oper_s3_buckets):
+    """Compose the 3h scenario fixtures into a single environment handle."""
+    yield IntegrationTest(table=oper_dynamodb_table_3h, s3=oper_s3_buckets)
+
+@pytest.fixture()
+def aws_environment_4h(oper_dynamodb_table_4h, oper_s3_buckets):
+    """Compose the 4h scenario fixtures into a single environment handle."""
+    yield IntegrationTest(table=oper_dynamodb_table_4h, s3=oper_s3_buckets)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -69,6 +69,7 @@ OPER_TARGET_BUCKET_EU = "target-bucket-europe"
 
 OPER_DA_0H  = "s4y_f2_ifs-da_od_oper_an_20260408T000000Z_20260408T000000Z_0h"
 OPER_ENS_0H = "s4y_f2_ifs-ens-cf_od_oper_fc_20260408T000000Z_20260408T000000Z_0h"
+OPER_ENS_2H = "s4y_f2_ifs-ens-cf_od_oper_fc_20260408T000000Z_20260408T020000Z_2h"
 OPER_ENS_3H = "s4y_f2_ifs-ens-cf_od_oper_fc_20260408T000000Z_20260408T030000Z_3h"
 OPER_ENS_4H = "s4y_f2_ifs-ens-cf_od_oper_fc_20260408T000000Z_20260408T040000Z_4h"
 
@@ -115,7 +116,7 @@ def _make_ddb_table(ddb):
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def oper_dynamodb_table(mocked_aws):
     """Create and pre-populate the DynamoDB table for the 4h scenario.
 
@@ -125,7 +126,7 @@ def oper_dynamodb_table(mocked_aws):
     ddb = boto3.resource("dynamodb", region_name="eu-central-1")
     table = _make_ddb_table(ddb)
     table.meta.client.get_waiter("table_exists").wait(TableName=DYNAMODB_TABLE_NAME)
-    for filename, step in [(OPER_DA_0H, 0), (OPER_ENS_0H, 0), (OPER_ENS_3H, 3)]:
+    for filename, step in [(OPER_DA_0H, 0), (OPER_ENS_0H, 0), (OPER_ENS_2H, 2), (OPER_ENS_3H, 3)]:
         table.put_item(Item={
             "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
             "ObjectKey": f"{OPER_PREFIX}/{filename}",
@@ -140,7 +141,7 @@ def oper_dynamodb_table(mocked_aws):
     yield table
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def oper_s3_buckets(mocked_aws):
     """Create source/target S3 buckets and upload all four test GRIB files.
 
@@ -154,7 +155,7 @@ def oper_s3_buckets(mocked_aws):
             Bucket=bucket,
             CreateBucketConfiguration={"LocationConstraint": "eu-central-1"},
         )
-    for filename in (OPER_DA_0H, OPER_ENS_0H, OPER_ENS_3H, OPER_ENS_4H):
+    for filename in (OPER_DA_0H, OPER_ENS_0H, OPER_ENS_2H, OPER_ENS_3H, OPER_ENS_4H):
         s3.upload_file(
             str(_resources / filename),
             OPER_SOURCE_BUCKET,
@@ -164,6 +165,6 @@ def oper_s3_buckets(mocked_aws):
 
 
 @pytest.fixture()
-def aws_4h_environment(oper_dynamodb_table, oper_s3_buckets):
+def aws_environment(oper_dynamodb_table, oper_s3_buckets):
     """Compose the three 4h scenario fixtures into a single environment handle."""
     yield Step4Test(table=oper_dynamodb_table, s3=oper_s3_buckets)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -131,6 +131,7 @@ def oper_dynamodb_table(mocked_aws):
             "ReferenceTime": str(OPER_REF_TIME),
             "LeadTime": step,
             "FileName": filename,
+            "Domain": "EUROPE",
             "CreatedAt": 0,
             "Status": "PENDING",
         })

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -64,7 +64,8 @@ OPER_REF_TIME    = datetime(2026, 4, 8, 0, 0, 0, tzinfo=timezone.utc)
 OPER_REF_TIME_TS = int(OPER_REF_TIME.timestamp())
 OPER_PREFIX      = "raw/s4y_f2/data"
 OPER_SOURCE_BUCKET = "source-bucket"
-OPER_TARGET_BUCKET = "target-bucket-europe"
+OPER_TARGET_BUCKET_GLOBAL = "target-bucket-global"
+OPER_TARGET_BUCKET_EU = "target-bucket-europe"
 
 OPER_DA_0H  = "s4y_f2_ifs-da_od_oper_an_20260408T000000Z_20260408T000000Z_0h"
 OPER_ENS_0H = "s4y_f2_ifs-ens-cf_od_oper_fc_20260408T000000Z_20260408T000000Z_0h"
@@ -148,7 +149,7 @@ def oper_s3_buckets(mocked_aws):
     """
     _resources = Path(__file__).parent / "resources"
     s3 = boto3.client("s3", region_name="eu-central-1")
-    for bucket in (OPER_SOURCE_BUCKET, OPER_TARGET_BUCKET):
+    for bucket in (OPER_SOURCE_BUCKET, OPER_TARGET_BUCKET_EU, OPER_TARGET_BUCKET_GLOBAL):
         s3.create_bucket(
             Bucket=bucket,
             CreateBucketConfiguration={"LocationConstraint": "eu-central-1"},

--- a/test/domain/test_db_utils.py
+++ b/test/domain/test_db_utils.py
@@ -26,6 +26,7 @@ FORECAST_REF_TIME = datetime(2026, 3, 31, 6, 0, 0, tzinfo=timezone.utc)
 REF_TIME_KEY = int(FORECAST_REF_TIME.timestamp())
 
 _FILENAME_TEMPLATE = "s4y_f2_ifs-ens-cf_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
+_F1_FILENAME_TEMPLATE = "s4y_f1_ifs-hres_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
 
 def _make_file(step: int, processed: bool = False) -> IFSForecastFile:
     filename = _FILENAME_TEMPLATE.format(step=step)
@@ -58,6 +59,7 @@ def _put_items(table, items: list[tuple[int, str]]) -> None:
             "ReferenceTime": str(FORECAST_REF_TIME),
             "LeadTime": step,
             "FileName": filename,
+            "Domain": "EUROPE",
             "CreatedAt": 0,
             "Status": status,
         })
@@ -67,6 +69,21 @@ def _put_item(table, step: int, status: str = "PENDING") -> None:
     """Convenience wrapper for inserting a single item (no duplicate-step handling)."""
     _put_items(table, [(step, status)])
 
+
+def _put_domain_item(table, step: int, domain: Feed, status: str = "PENDING", prefix: str = "prefix") -> None:
+    """Insert a single item for the given domain using the appropriate filename template."""
+    template = _FILENAME_TEMPLATE if domain == Feed.F2 else _F1_FILENAME_TEMPLATE
+    filename = template.format(step=step)
+    table.put_item(Item={
+        "ReferenceTimePartitionKey": REF_TIME_KEY,
+        "ObjectKey": f"{prefix}/{filename}",
+        "ReferenceTime": str(FORECAST_REF_TIME),
+        "LeadTime": step,
+        "FileName": filename,
+        "Domain": domain.value,
+        "CreatedAt": 0,
+        "Status": status,
+    })
 
 
 @pytest.fixture
@@ -91,6 +108,7 @@ class TestDynamodbItemToIFSForecastFile:
             "ObjectKey": f"prefix/{filename}",
             "LeadTime": 6,
             "FileName": filename,
+            "Domain": "EUROPE",
             "Status": "PENDING",
         }
         f = dynamodb_item_to_ifs_forecast_file(item)
@@ -103,6 +121,7 @@ class TestDynamodbItemToIFSForecastFile:
             "ObjectKey": f"prefix/{filename}",
             "LeadTime": 12,
             "FileName": filename,
+            "Domain": "EUROPE",
             "Status": "PENDING",
         }
         f = dynamodb_item_to_ifs_forecast_file(item)
@@ -116,6 +135,7 @@ class TestDynamodbItemToIFSForecastFile:
             "ObjectKey": key,
             "LeadTime": 6,
             "FileName": filename,
+            "Domain": "EUROPE",
             "Status": "PENDING",
         }
         f = dynamodb_item_to_ifs_forecast_file(item)
@@ -155,7 +175,7 @@ class TestGetStepsToProcess:
         """Populate table with (step, status) items and call get_steps_to_process."""
         _put_items(table, items)
 
-        return get_steps_to_process(FORECAST_REF_TIME)
+        return get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
 
     def test_returns_empty_when_no_step_zero(self, ddb_table):
 
@@ -226,6 +246,51 @@ class TestGetStepsToProcess:
         statuses.append((0, "PROCESSED"))
         items_to_process, _ = self._run(ddb_table, statuses)
         assert len(items_to_process) == len(pending_steps)
+
+    def test_ignores_predecessor_from_different_domain(self, ddb_table):
+        """A PENDING F2 step=6 must not be queued when only an F1 step=3 exists.
+
+        The step=3 predecessor is present in DynamoDB but belongs to a different
+        domain (F1/GLOBAL).  The query must filter it out so that step=6 is not
+        treated as processable.
+        """
+        # Two F2 step=0 files satisfy the gate condition
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED", prefix="prefix2")
+        # Only F1 has step=3 – the F2 predecessor is missing
+        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status="PROCESSED")
+        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status="PENDING")
+
+        items_to_process, _ = get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
+
+        assert items_to_process == [], (
+            "step=6 should not be queued because its F2 predecessor (step=3) is absent"
+        )
+
+    def test_only_returns_items_for_requested_domain(self, ddb_table):
+        """Results must contain only items belonging to the requested domain.
+
+        When both F1 and F2 items are present for the same reference time,
+        querying for F2 must return step-zero files and processable pairs
+        exclusively from F2.
+        """
+        # F2: full chain – two step=0, step=3 PROCESSED, step=6 PENDING
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED", prefix="prefix2")
+        _put_domain_item(ddb_table, step=3, domain=Feed.F2, status="PROCESSED")
+        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status="PENDING")
+        # F1: also has items in the same table
+        _put_domain_item(ddb_table, step=0, domain=Feed.F1, status="PROCESSED", prefix="f1prefix")
+        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status="PROCESSED", prefix="f1prefix")
+
+        items_to_process, zeros = get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
+
+        assert all(z.domain == Feed.F2 for z in zeros), "step-zero list must contain only F2 items"
+        assert len(zeros) == 2
+        assert len(items_to_process) == 1
+        current, prev = items_to_process[0]
+        assert current.domain == Feed.F2
+        assert prev.domain == Feed.F2
 
 
 # ---------------------------------------------------------------------------

--- a/test/domain/test_db_utils.py
+++ b/test/domain/test_db_utils.py
@@ -25,18 +25,8 @@ from conftest import _make_ddb_table
 FORECAST_REF_TIME = datetime(2026, 3, 31, 6, 0, 0, tzinfo=timezone.utc)
 REF_TIME_KEY = int(FORECAST_REF_TIME.timestamp())
 
-_FILENAME_TEMPLATE = "s4y_f2_ifs-ens-cf_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
+_F2_FILENAME_TEMPLATE = "s4y_f2_ifs-ens-cf_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
 _F1_FILENAME_TEMPLATE = "s4y_f1_ifs-hres_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
-
-def _make_file(step: int, processed: bool = False) -> IFSForecastFile:
-    filename = _FILENAME_TEMPLATE.format(step=step)
-    return IFSForecastFile(
-        object_key=f"prefix/{filename}",
-        filename=filename,
-        forecast_ref_time=FORECAST_REF_TIME,
-        step=step,
-        processed=processed,
-    )
 
 
 def _put_items(table, items: list[tuple[int, str]]) -> None:
@@ -52,7 +42,7 @@ def _put_items(table, items: list[tuple[int, str]]) -> None:
         idx = step_counts.get(step, 0)
         step_counts[step] = idx + 1
         prefix = "prefix" if idx == 0 else f"prefix{idx + 1}"
-        filename = _FILENAME_TEMPLATE.format(step=step)
+        filename = _F2_FILENAME_TEMPLATE.format(step=step)
         table.put_item(Item={
             "ReferenceTimePartitionKey": REF_TIME_KEY,
             "ObjectKey": f"{prefix}/{filename}",
@@ -61,7 +51,8 @@ def _put_items(table, items: list[tuple[int, str]]) -> None:
             "FileName": filename,
             "Domain": "EUROPE",
             "CreatedAt": 0,
-            "Status": status,
+            "Status_1h": status,
+            "Status_3h": status
         })
 
 
@@ -70,9 +61,9 @@ def _put_item(table, step: int, status: str = "PENDING") -> None:
     _put_items(table, [(step, status)])
 
 
-def _put_domain_item(table, step: int, domain: Feed, status: str = "PENDING", prefix: str = "prefix") -> None:
+def _put_domain_item(table, step: int, domain: Feed, status1: str = "PENDING", status3: str = "PENDING", prefix: str = "prefix") -> None:
     """Insert a single item for the given domain using the appropriate filename template."""
-    template = _FILENAME_TEMPLATE if domain == Feed.F2 else _F1_FILENAME_TEMPLATE
+    template = _F2_FILENAME_TEMPLATE if domain == Feed.F2 else _F1_FILENAME_TEMPLATE
     filename = template.format(step=step)
     table.put_item(Item={
         "ReferenceTimePartitionKey": REF_TIME_KEY,
@@ -82,7 +73,8 @@ def _put_domain_item(table, step: int, domain: Feed, status: str = "PENDING", pr
         "FileName": filename,
         "Domain": domain.value,
         "CreatedAt": 0,
-        "Status": status,
+        "Status_1h": status1,
+        "Status_3h": status3
     })
 
 
@@ -102,7 +94,7 @@ def ddb_table():
 class TestDynamodbItemToIFSForecastFile:
 
     def test_forecast_ref_time_roundtrip(self):
-        filename = _FILENAME_TEMPLATE.format(step=6)
+        filename = _F2_FILENAME_TEMPLATE.format(step=6)
         item = {
             "ReferenceTimePartitionKey": REF_TIME_KEY,
             "ObjectKey": f"prefix/{filename}",
@@ -115,7 +107,7 @@ class TestDynamodbItemToIFSForecastFile:
         assert f.forecast_ref_time == FORECAST_REF_TIME
 
     def test_step_stored(self):
-        filename = _FILENAME_TEMPLATE.format(step=12)
+        filename = _F2_FILENAME_TEMPLATE.format(step=12)
         item = {
             "ReferenceTimePartitionKey": REF_TIME_KEY,
             "ObjectKey": f"prefix/{filename}",
@@ -128,7 +120,7 @@ class TestDynamodbItemToIFSForecastFile:
         assert f.step == 12
 
     def test_object_key_stored(self):
-        filename = _FILENAME_TEMPLATE.format(step=6)
+        filename = _F2_FILENAME_TEMPLATE.format(step=6)
         key = f"prefix/{filename}"
         item = {
             "ReferenceTimePartitionKey": REF_TIME_KEY,
@@ -150,7 +142,14 @@ class TestDynamodbItemToIFSForecastFile:
 class TestWriteProductIndex:
     def test_writes_item_to_table(self, ddb_table):
 
-        f = _make_file(step=6)
+        filename = _F2_FILENAME_TEMPLATE.format(step=6)
+        f = IFSForecastFile(
+            object_key=f"prefix/{filename}",
+            filename=filename,
+            forecast_ref_time=FORECAST_REF_TIME,
+            step=6
+        )
+
         write_product_index(f)
         item = ddb_table.get_item(
             Key={
@@ -159,7 +158,8 @@ class TestWriteProductIndex:
             }
         )["Item"]
         assert item["LeadTime"] == 6
-        assert item["Status"] == "PENDING"
+        assert item["Status_1h"] == "PENDING"
+        assert item["Status_3h"] == "PENDING"
         assert item["FileName"] == f.filename
         assert "CreatedAt" in item
 
@@ -175,7 +175,7 @@ class TestGetStepsToProcess:
         """Populate table with (step, status) items and call get_steps_to_process."""
         _put_items(table, items)
 
-        return get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
+        return get_steps_to_process(FORECAST_REF_TIME, Feed.F2, tincr=3)
 
     def test_returns_empty_when_no_step_zero(self, ddb_table):
 
@@ -205,6 +205,7 @@ class TestGetStepsToProcess:
             ddb_table,
             [(0, "PROCESSED"), (0, "PROCESSED"), (3, "PROCESSED"), (6, "PENDING")],
         )
+
         assert len(items_to_process) == 1
         current, prev = items_to_process[0]
         assert current.step == 6
@@ -255,11 +256,11 @@ class TestGetStepsToProcess:
         treated as processable.
         """
         # Two F2 step=0 files satisfy the gate condition
-        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED")
-        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED", prefix="prefix2")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status1="PROCESSED")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status1="PROCESSED", prefix="prefix2")
         # Only F1 has step=3 – the F2 predecessor is missing
-        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status="PROCESSED")
-        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status="PENDING")
+        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status1="PROCESSED")
+        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status1="PENDING")
 
         items_to_process, _ = get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
 
@@ -275,15 +276,15 @@ class TestGetStepsToProcess:
         exclusively from F2.
         """
         # F2: full chain – two step=0, step=3 PROCESSED, step=6 PENDING
-        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED")
-        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status="PROCESSED", prefix="prefix2")
-        _put_domain_item(ddb_table, step=3, domain=Feed.F2, status="PROCESSED")
-        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status="PENDING")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status3="PROCESSED")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F2, status3="PROCESSED", prefix="prefix2")
+        _put_domain_item(ddb_table, step=3, domain=Feed.F2, status3="PROCESSED")
+        _put_domain_item(ddb_table, step=6, domain=Feed.F2, status3="PENDING")
         # F1: also has items in the same table
-        _put_domain_item(ddb_table, step=0, domain=Feed.F1, status="PROCESSED", prefix="f1prefix")
-        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status="PROCESSED", prefix="f1prefix")
+        _put_domain_item(ddb_table, step=0, domain=Feed.F1, status3="PROCESSED", prefix="f1prefix")
+        _put_domain_item(ddb_table, step=3, domain=Feed.F1, status3="PROCESSED", prefix="f1prefix")
 
-        items_to_process, zeros = get_steps_to_process(FORECAST_REF_TIME, Feed.F2)
+        items_to_process, zeros = get_steps_to_process(FORECAST_REF_TIME, Feed.F2, tincr=3)
 
         assert all(z.domain == Feed.F2 for z in zeros), "step-zero list must contain only F2 items"
         assert len(zeros) == 2
@@ -302,7 +303,7 @@ class TestUpdateProductIndexProcessed:
     def test_processed_at_is_set(self, ddb_table):
 
         _put_item(ddb_table, step=6, status="PENDING")
-        filename = _FILENAME_TEMPLATE.format(step=6)
+        filename = _F2_FILENAME_TEMPLATE.format(step=6)
         object_key = f"prefix/{filename}"
 
         update_product_index_processed(object_key, FORECAST_REF_TIME)

--- a/test/domain/test_db_utils.py
+++ b/test/domain/test_db_utils.py
@@ -83,21 +83,6 @@ def ddb_table():
 
 
 class TestDynamodbItemToIFSForecastFile:
-    @pytest.mark.parametrize("status, expected_processed", [
-        ("PENDING", False),
-        ("PROCESSED", True),
-    ])
-    def test_status_maps_to_processed(self, status, expected_processed):
-        filename = _FILENAME_TEMPLATE.format(step=6)
-        item = {
-            "ReferenceTimePartitionKey": REF_TIME_KEY,
-            "ObjectKey": f"prefix/{filename}",
-            "LeadTime": 6,
-            "FileName": filename,
-            "Status": status,
-        }
-        f = dynamodb_item_to_ifs_forecast_file(item)
-        assert f.processed == expected_processed
 
     def test_forecast_ref_time_roundtrip(self):
         filename = _FILENAME_TEMPLATE.format(step=6)

--- a/test/domain/test_processing.py
+++ b/test/domain/test_processing.py
@@ -136,7 +136,7 @@ class TestGenerateAndUploadGribFile:
         )
         with patch("flexpart_ifs_preprocessor.domain.processing.write_grib", return_value=[fake_path]) as mock_write, \
              patch("flexpart_ifs_preprocessor.domain.processing.upload_to_s3"):
-            _generate_and_upload_grib_file(tmp_path, processed_fields, input_file)
+            _generate_and_upload_grib_file(tmp_path, processed_fields, input_file, tincr=3)
             assert mock_write.call_args.kwargs["prefix"] == expected_prefix
 
     def test_upload_called_for_each_written_path(self, processed_fields, input_file, tmp_path):

--- a/test/test_lambda_handler.py
+++ b/test/test_lambda_handler.py
@@ -174,7 +174,7 @@ class TestLambdaHandler:
              patch("flexpart_ifs_preprocessor.flexpart_ifs_preprocessor.update_product_index_processed", mocks["update_product_index_processed"]):
             lambda_handler(event, MagicMock())
 
-        mocks["run_preprocessing"].assert_called_once_with(real_file, real_prev, real_zeros)
+        mocks["run_preprocessing"].assert_called_once_with(real_file, real_prev, real_zeros, 1)
 
     def test_multiple_files_in_event_each_processed_independently(self):
         mocks = self._make_mocks()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,7 +1,7 @@
 """End-to-end integration test: lambda_handler processes the 4h GRIB file.
 
 AWS resources (DynamoDB, S3) are fully mocked with moto via the
-``aws_4h_environment`` fixture defined in conftest.py.  The real compressed
+``aws_environment`` fixture defined in conftest.py.  The real compressed
 GRIB files from test/resources are uploaded to the mocked source bucket so
 that download_file → load_grib → preprocess → write_grib → upload_to_s3
 all run against actual data.
@@ -26,6 +26,7 @@ from conftest import (
     OPER_PREFIX,
     OPER_REF_TIME_TS,
     OPER_TARGET_BUCKET_EU,
+    OPER_TARGET_BUCKET_GLOBAL,
     _kafka_event,
 )
 
@@ -37,26 +38,29 @@ from conftest import (
 class TestProcess4hEndToEnd:
     """lambda_handler processes the 4h GRIB file end-to-end against mocked AWS."""
 
-    def test_output_uploaded_to_target_s3(self, aws_4h_environment):
+    def test_output_uploaded_to_target_s3(self, aws_environment):
         """After processing the 4h file, at least one dispf* file appears in target S3."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_4H), None)
 
-        resp = aws_4h_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
+        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
         assert "Contents" in resp, "No files were uploaded to the target S3 bucket"
         keys = [obj["Key"] for obj in resp["Contents"]]
         assert any(k.startswith("dispf") for k in keys), (
             f"Expected a dispf* output file in target bucket, got: {keys}"
         )
 
-    def test_4h_item_marked_processed_in_dynamodb(self, aws_4h_environment):
+        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_GLOBAL)
+        assert "Contents" not in resp, "Files were uploaded to the target S3 bucket when none were expected"
+
+    def test_4h_item_marked_processed_in_dynamodb(self, aws_environment):
         """DynamoDB Status for the 4h file is set to PROCESSED after lambda_handler."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_4H), None)
 
-        item = aws_4h_environment.table.get_item(Key={
+        item = aws_environment.table.get_item(Key={
             "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
             "ObjectKey": f"{OPER_PREFIX}/{OPER_ENS_4H}",
         }).get("Item")
@@ -68,21 +72,63 @@ class TestProcess4hEndToEnd:
             f"Expected Status=PENDING for the 4h item, got: {item['Status']}"
         )
 
-    def test_prerequisite_items_remain_pending(self, aws_4h_environment):
+    def test_prerequisite_items_remain_pending(self, aws_environment):
         """The step-0 and step-3 DB entries are not touched – they stay PENDING."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_4H), None)
 
         for filename, step in [(OPER_DA_0H, 0), (OPER_ENS_0H, 0), (OPER_ENS_3H, 3)]:
-            item = aws_4h_environment.table.get_item(Key={
+            item = aws_environment.table.get_item(Key={
                 "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
                 "ObjectKey": f"{OPER_PREFIX}/{filename}",
             }).get("Item")
             assert item is not None, f"Item for {filename} not found in DynamoDB"
             assert item["Status_1h"] == "PENDING", (
-                f"{filename} should still be PENDING but got: {item['Status']}"
+                f"{filename} should still be PENDING but got: {item['Status_1h']}"
             )
             assert item["Status_3h"] == "PENDING", (
-                f"{filename} should still be PENDING but got: {item['Status']}"
+                f"{filename} should still be PENDING but got: {item['Status_3h']}"
             )
+
+
+class TestProcess3hEndToEnd:
+    """lambda_handler processes the 3h GRIB file end-to-end against mocked AWS."""
+
+    def test_output_uploaded_to_target_s3(self, aws_environment):
+        """After processing the 4h file, at least one dispf* file appears in target S3."""
+        from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
+
+        lambda_handler(_kafka_event(OPER_ENS_3H), None)
+
+        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
+
+        assert "Contents" in resp, "No files were uploaded to the target S3 bucket (europe)"
+        keys = [obj["Key"] for obj in resp["Contents"]]
+        assert any(k.startswith("dispf") for k in keys), (
+            f"Expected a dispf* output file in target bucket, got: {keys}"
+        )
+        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_GLOBAL)
+        assert "Contents" in resp, "No files were uploaded to the target S3 bucket (global)"
+        keys = [obj["Key"] for obj in resp["Contents"]]
+        assert any(k.startswith("dispf") for k in keys), (
+            f"Expected a dispf* output file in target bucket, got: {keys}"
+        )
+
+    def test_3h_item_marked_processed_in_dynamodb(self, aws_environment):
+        """DynamoDB Status for the 4h file is set to PROCESSED after lambda_handler."""
+        from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
+
+        lambda_handler(_kafka_event(OPER_ENS_3H), None)
+
+        item = aws_environment.table.get_item(Key={
+            "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
+            "ObjectKey": f"{OPER_PREFIX}/{OPER_ENS_3H}",
+        }).get("Item")
+        assert item is not None, "3h DynamoDB item not found"
+        assert item["Status_1h"] == "PROCESSED", (
+            f"Expected Status=PROCESSED for the 3h item, got: {item['Status_1h']}"
+        )
+        assert item["Status_3h"] == "PROCESSED", (
+            f"Expected Status=PROCESSED for the 3h item, got: {item['Status_3h']}"
+        )

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -38,29 +38,29 @@ from conftest import (
 class TestProcess4hEndToEnd:
     """lambda_handler processes the 4h GRIB file end-to-end against mocked AWS."""
 
-    def test_output_uploaded_to_target_s3(self, aws_environment):
+    def test_output_uploaded_to_target_s3(self, aws_environment_4h):
         """After processing the 4h file, at least one dispf* file appears in target S3."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_4H), None)
 
-        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
+        resp = aws_environment_4h.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
         assert "Contents" in resp, "No files were uploaded to the target S3 bucket"
         keys = [obj["Key"] for obj in resp["Contents"]]
         assert any(k.startswith("dispf") for k in keys), (
             f"Expected a dispf* output file in target bucket, got: {keys}"
         )
 
-        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_GLOBAL)
+        resp = aws_environment_4h.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_GLOBAL)
         assert "Contents" not in resp, "Files were uploaded to the target S3 bucket when none were expected"
 
-    def test_4h_item_marked_processed_in_dynamodb(self, aws_environment):
+    def test_4h_item_marked_processed_in_dynamodb(self, aws_environment_4h):
         """DynamoDB Status for the 4h file is set to PROCESSED after lambda_handler."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_4H), None)
 
-        item = aws_environment.table.get_item(Key={
+        item = aws_environment_4h.table.get_item(Key={
             "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
             "ObjectKey": f"{OPER_PREFIX}/{OPER_ENS_4H}",
         }).get("Item")
@@ -72,14 +72,14 @@ class TestProcess4hEndToEnd:
             f"Expected Status=PENDING for the 4h item, got: {item['Status']}"
         )
 
-    def test_prerequisite_items_remain_pending(self, aws_environment):
+    def test_prerequisite_items_remain_pending(self, aws_environment_4h):
         """The step-0 and step-3 DB entries are not touched – they stay PENDING."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_4H), None)
 
         for filename, step in [(OPER_DA_0H, 0), (OPER_ENS_0H, 0), (OPER_ENS_3H, 3)]:
-            item = aws_environment.table.get_item(Key={
+            item = aws_environment_4h.table.get_item(Key={
                 "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
                 "ObjectKey": f"{OPER_PREFIX}/{filename}",
             }).get("Item")
@@ -95,33 +95,33 @@ class TestProcess4hEndToEnd:
 class TestProcess3hEndToEnd:
     """lambda_handler processes the 3h GRIB file end-to-end against mocked AWS."""
 
-    def test_output_uploaded_to_target_s3(self, aws_environment):
+    def test_output_uploaded_to_target_s3(self, aws_environment_3h):
         """After processing the 4h file, at least one dispf* file appears in target S3."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_3H), None)
 
-        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
+        resp = aws_environment_3h.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
 
         assert "Contents" in resp, "No files were uploaded to the target S3 bucket (europe)"
         keys = [obj["Key"] for obj in resp["Contents"]]
         assert any(k.startswith("dispf") for k in keys), (
             f"Expected a dispf* output file in target bucket, got: {keys}"
         )
-        resp = aws_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_GLOBAL)
+        resp = aws_environment_3h.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_GLOBAL)
         assert "Contents" in resp, "No files were uploaded to the target S3 bucket (global)"
         keys = [obj["Key"] for obj in resp["Contents"]]
         assert any(k.startswith("dispf") for k in keys), (
             f"Expected a dispf* output file in target bucket, got: {keys}"
         )
 
-    def test_3h_item_marked_processed_in_dynamodb(self, aws_environment):
+    def test_3h_item_marked_processed_in_dynamodb(self, aws_environment_3h):
         """DynamoDB Status for the 4h file is set to PROCESSED after lambda_handler."""
         from flexpart_ifs_preprocessor.flexpart_ifs_preprocessor import lambda_handler
 
         lambda_handler(_kafka_event(OPER_ENS_3H), None)
 
-        item = aws_environment.table.get_item(Key={
+        item = aws_environment_3h.table.get_item(Key={
             "ReferenceTimePartitionKey": OPER_REF_TIME_TS,
             "ObjectKey": f"{OPER_PREFIX}/{OPER_ENS_3H}",
         }).get("Item")

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -25,7 +25,7 @@ from conftest import (
     OPER_ENS_3H,
     OPER_PREFIX,
     OPER_REF_TIME_TS,
-    OPER_TARGET_BUCKET,
+    OPER_TARGET_BUCKET_EU,
     _kafka_event,
 )
 
@@ -43,7 +43,7 @@ class TestProcess4hEndToEnd:
 
         lambda_handler(_kafka_event(OPER_ENS_4H), None)
 
-        resp = aws_4h_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET)
+        resp = aws_4h_environment.s3.list_objects_v2(Bucket=OPER_TARGET_BUCKET_EU)
         assert "Contents" in resp, "No files were uploaded to the target S3 bucket"
         keys = [obj["Key"] for obj in resp["Contents"]]
         assert any(k.startswith("dispf") for k in keys), (

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -61,8 +61,11 @@ class TestProcess4hEndToEnd:
             "ObjectKey": f"{OPER_PREFIX}/{OPER_ENS_4H}",
         }).get("Item")
         assert item is not None, "4h DynamoDB item not found"
-        assert item["Status"] == "PROCESSED", (
+        assert item["Status_1h"] == "PROCESSED", (
             f"Expected Status=PROCESSED for the 4h item, got: {item['Status']}"
+        )
+        assert item["Status_3h"] == "PENDING", (
+            f"Expected Status=PENDING for the 4h item, got: {item['Status']}"
         )
 
     def test_prerequisite_items_remain_pending(self, aws_4h_environment):
@@ -77,6 +80,9 @@ class TestProcess4hEndToEnd:
                 "ObjectKey": f"{OPER_PREFIX}/{filename}",
             }).get("Item")
             assert item is not None, f"Item for {filename} not found in DynamoDB"
-            assert item["Status"] == "PENDING", (
+            assert item["Status_1h"] == "PENDING", (
+                f"{filename} should still be PENDING but got: {item['Status']}"
+            )
+            assert item["Status_3h"] == "PENDING", (
                 f"{filename} should still be PENDING but got: {item['Status']}"
             )


### PR DESCRIPTION
EU IFS data is produced every hour.

Global IFS data is produced every 3 hours.

For Flexpart IFS Global (nested) runs, the EU domain data is also required for the nested domain. However, the european domain IFS data is preprocessed for 1h (including deagregation of fields eg precipitation). This is then not correct to be used for the nest in global runs, because global IFS data is only 3 hourly, and deaccumulated as such. This means that the IFS EU data which step % 3 == 0 should also be processed with the correct deaccumulation (tincr = 3) and be uploaded to the global bucket. That is in addition to the normal processing with tincr =1.