### PR TITLE
DT-363 Only 3 houly dispf files for global IFS input

### DIFF
--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -16,6 +16,9 @@ def write_product_index(event: IFSForecastFile) -> None:
     # Adding created_at parameter for tracking files longevity
     creation_timestamp = int(datetime.now(UTC).timestamp())
 
+    # TTL set to 2 days from now
+    ttl_timestamp = creation_timestamp + (2 * 24 * 60 * 60)
+
     message = {
         'ReferenceTimePartitionKey': int(event.forecast_ref_time.timestamp()),  # Partition Key
         'ObjectKey': event.object_key,  # DynamoDB Primary Sort Key
@@ -24,6 +27,7 @@ def write_product_index(event: IFSForecastFile) -> None:
         'FileName': event.filename,
         'Domain': str(event.domain.value),
         'CreatedAt': creation_timestamp,
+        'TTL': ttl_timestamp,
         f'Status_3h': 'PENDING',
         f'Status_1h': 'PENDING',
     }

--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from datetime import datetime, UTC
 
 import boto3

--- a/flexpart_ifs_preprocessor/domain/db_utils.py
+++ b/flexpart_ifs_preprocessor/domain/db_utils.py
@@ -31,10 +31,10 @@ def write_product_index(event: IFSForecastFile) -> None:
         f'Status_3h': 'PENDING',
         f'Status_1h': 'PENDING',
     }
-    if event.domain == 'F1':
+    if event.domain == Feed.F1:
         # For F1 (GLOBAL) files, only 3-hourly preprocessing is needed, so we can set the 1-hourly status to 'N/A'.
         message['Status_1h'] = 'N/A'
-    elif event.domain == 'F2' and event.step % 3 != 0:
+    elif event.domain == Feed.F2 and event.step % 3 != 0:
         # For F2 (EUROPE) files that are not on 3-hourly steps, only 1-hourly preprocessing is needed, so we can set the 3-hourly status to 'N/A'.
         message['Status_3h'] = 'N/A'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexpart-ifs-preprocessor"
-version = "0.4.0"
+version = "0.5.0"
 description = "Preprocesses IFS data for use in Flexpart"
 license = "BSD-3-Clause"
 authors = [

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -66,10 +66,10 @@ class TestProcess4hEndToEnd:
         }).get("Item")
         assert item is not None, "4h DynamoDB item not found"
         assert item["Status_1h"] == "PROCESSED", (
-            f"Expected Status=PROCESSED for the 4h item, got: {item['Status']}"
+            f"Expected Status=PROCESSED for the 4h item, got: {item['Status_1h']}"
         )
-        assert item["Status_3h"] == "PENDING", (
-            f"Expected Status=PENDING for the 4h item, got: {item['Status']}"
+        assert item["Status_3h"] == "N/A", (
+            f"Expected Status=N/A for the 4h item, got: {item['Status_3h']}"
         )
 
     def test_prerequisite_items_remain_pending(self, aws_environment_4h):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -132,3 +132,26 @@ class TestProcess3hEndToEnd:
         assert item["Status_3h"] == "PROCESSED", (
             f"Expected Status=PROCESSED for the 3h item, got: {item['Status_3h']}"
         )
+
+
+def test_non_3hourly_f2_steps_have_status_3h_na(mocked_aws, oper_dynamodb_table_3h):
+    """F2 steps not divisible by 3 should have Status_3h='N/A' to prevent 3h processing."""
+    from flexpart_ifs_preprocessor.domain.db_utils import write_product_index, get_steps_to_process
+    from flexpart_ifs_preprocessor.domain.data_model import IFSForecastFile, Feed
+    from datetime import datetime, timezone
+
+    # Create F2 event with step=5 (not divisible by 3)
+    ref_time = datetime(2026, 4, 28, 6, 0, 0, tzinfo=timezone.utc)
+    event = IFSForecastFile(
+        object_key="raw/s4y_f2/data/s4y_f2_ifs-ens-cf_od_oper_fc_20260428T060000Z_20260428T110000Z_5h",
+        filename="s4y_f2_ifs-ens-cf_od_oper_fc_20260428T060000Z_20260428T110000Z_5h",
+        domain=Feed.F2,
+        forecast_ref_time=ref_time,
+        step=5
+    )
+
+    write_product_index(event)
+
+    # Query with tincr=3 should return empty (step=5 shouldn't be processed with tincr=3)
+    items_to_process, _ = get_steps_to_process(ref_time, Feed.F2, tincr=3)
+    assert len(items_to_process) == 0, "Non-3-hourly F2 steps should not be returned for tincr=3 processing"


### PR DESCRIPTION
Fix: Prevent non-3-hourly F2 steps from being processed with `tincr=3`
Set `Status_3h = 'N/A'` for F2 steps where `step % 3 != 0` at creation time
This prevents `get_steps_to_process(tincr=3)` from returning these steps, so hourly data only gets uploaded to the Europe bucket

Add TTL field (2 days) to DynamoDB entries for automatic cleanup