### PR TITLE
Process 3 hourly only 0UTC and 12UTC forecasts

### DIFF
--- a/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
+++ b/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
@@ -45,12 +45,15 @@ def lambda_handler(event: ConsumerRecords, _: LambdaContext) -> None:
                 # - 3-hourly: for nesting the Europe domain into the global runs, which requires
                 #   3-hourly NWP data with aggregated values (e.g. precipitation, fluxes) averaged
                 #   over 3 hours.
-                if file_event.domain == Feed.F1:
+                if file_event.domain == Feed.F1 and file_event.forecast_ref_time.hour in (0,12):
                     tincr_list = [3]
-                elif file_event.domain == Feed.F2 and file_event.step % 3 == 0:
+                elif file_event.domain == Feed.F2 and file_event.forecast_ref_time.hour in (0,12) and file_event.step % 3 == 0 :
                     tincr_list = [1,3]
                 elif file_event.domain == Feed.F2:
                     tincr_list = [1]
+                else:
+                    logger.info("Skipping record offset=%s, not a relevant feed/forecast_datetime", kafka_record.get("offset"))
+                    continue
 
                 for tincr in tincr_list:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexpart-ifs-preprocessor"
-version = "0.7.1"
+version = "0.7.2"
 description = "Preprocesses IFS data for use in Flexpart"
 license = "BSD-3-Clause"
 authors = [

--- a/test/test_lambda_handler.py
+++ b/test/test_lambda_handler.py
@@ -196,7 +196,7 @@ class TestLambdaHandler:
             lambda_handler(event, MagicMock())
 
         assert mocks["write_product_index"].call_count == 2
-        assert mocks["get_steps_to_process"].call_count == 2
+        assert mocks["get_steps_to_process"].call_count == 1 # F1 feed (global) for 6UTC is not processed
 
     def test_filtered_records_do_not_trigger_writes(self):
         """Records with unknown stream/feed should be silently discarded."""


### PR DESCRIPTION
Im not sure whether this is required actually. Maybe we want the data from 6,18UTC for the rolling archive? @pirmink 