### PR TITLE
Update model name for flexpart input uploads

### DIFF
--- a/flexpart_ifs_preprocessor/domain/processing.py
+++ b/flexpart_ifs_preprocessor/domain/processing.py
@@ -53,11 +53,11 @@ def _generate_and_upload_grib_file(output_dir: Path,
     logger.info("Writing GRIB2 file to %s ...", output_dir)
 
     _UPLOAD_CONFIG: dict[tuple[Feed, int], tuple[str, str, str]] = {
-        (Feed.F1, 3):    ("dispc", CONFIG.main.target_s3_bucket_name_global, "IFS-HRES"),
-        # when uploading to GLOBAL bucket a EUROPE domain file, use IFS-HRES as model name
+        (Feed.F1, 3):    ("dispc", CONFIG.main.target_s3_bucket_name_global, "IFS-Global"),
+        # when uploading to GLOBAL bucket a EUROPE domain file, use IFS-Global as model name
         # (as convention with lead time aggregator)
-        (Feed.F2, 3):    ("dispf", CONFIG.main.target_s3_bucket_name_global, "IFS-HRES"),
-        (Feed.F2, 1):    ("dispf", CONFIG.main.target_s3_bucket_name_europe, "IFS-HRES-Europe"),
+        (Feed.F2, 3):    ("dispf", CONFIG.main.target_s3_bucket_name_global, "IFS-Global"),
+        (Feed.F2, 1):    ("dispf", CONFIG.main.target_s3_bucket_name_europe, "IFS-Europe"),
     }
 
     config = _UPLOAD_CONFIG.get((input_file.domain, tincr))

--- a/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
+++ b/flexpart_ifs_preprocessor/flexpart_ifs_preprocessor.py
@@ -1,4 +1,4 @@
-"""Pre-Process IFS HRES data as input to Flexpart."""
+"""Pre-Process IFS data as input to Flexpart."""
 
 import json
 import logging

--- a/test/domain/test_db_utils.py
+++ b/test/domain/test_db_utils.py
@@ -26,7 +26,7 @@ FORECAST_REF_TIME = datetime(2026, 3, 31, 6, 0, 0, tzinfo=timezone.utc)
 REF_TIME_KEY = int(FORECAST_REF_TIME.timestamp())
 
 _F2_FILENAME_TEMPLATE = "s4y_f2_ifs-ens-cf_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
-_F1_FILENAME_TEMPLATE = "s4y_f1_ifs-hres_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
+_F1_FILENAME_TEMPLATE = "s4y_f1_ifs-ens-cf_od_scda_fc_20260331T060000Z_20260403T080000Z_{step}h"
 
 
 def _put_items(table, items: list[tuple[int, str]]) -> None:

--- a/test/domain/test_processing.py
+++ b/test/domain/test_processing.py
@@ -168,9 +168,9 @@ class TestGenerateAndUploadGribFile:
         assert not fake_path.exists()
 
     @pytest.mark.parametrize("tincr,input_file,expected_model,expected_domain", [
-        [1, IFSForecastFile(object_key=_F2_FILENAME,filename=_F2_FILENAME,), "IFS-HRES-Europe", "EUROPE"],
-        [3, IFSForecastFile(object_key=_F2_FILENAME,filename=_F2_FILENAME,), "IFS-HRES", "EUROPE"],
-        [3, IFSForecastFile(object_key=_F1_FILENAME,filename=_F1_FILENAME,), "IFS-HRES", "GLOBAL"],
+        [1, IFSForecastFile(object_key=_F2_FILENAME,filename=_F2_FILENAME,), "IFS-Europe", "EUROPE"],
+        [3, IFSForecastFile(object_key=_F2_FILENAME,filename=_F2_FILENAME,), "IFS-Global", "EUROPE"],
+        [3, IFSForecastFile(object_key=_F1_FILENAME,filename=_F1_FILENAME,), "IFS-Global", "GLOBAL"],
     ])
     def test_upload_metadata_contains_required_keys(self, processed_fields, input_file,
                                                     fake_path, tmp_path, tincr, expected_model, expected_domain):

--- a/test/domain/test_s3_utils.py
+++ b/test/domain/test_s3_utils.py
@@ -63,7 +63,7 @@ def s3_client_with_target_bucket():
 class TestUploadToS3:
     def test_metadata_attached(self, s3_client_with_target_bucket):
         s3 = s3_client_with_target_bucket
-        metadata = {"model": "IFS_HRES", "date": "20260331", "step": 74}
+        metadata = {"model": "IFS_Global", "date": "20260331", "step": 74}
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp.write(DUMMY_CONTENT)
             tmp_path = Path(tmp.name)
@@ -74,7 +74,7 @@ class TestUploadToS3:
             # The metadata should carry a 'data' key with JSON metadata
             assert "data" in stored_meta
             private = json.loads(stored_meta["data"])
-            assert private["model"] == "IFS_HRES"
+            assert private["model"] == "IFS_Global"
         finally:
             tmp_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
Change model name from IFS-HRES to IFS-Global and from IFS-HRES-Europe to IFS-Europe. This name is used as prefix in the flexpart input bucket. The lead-time aggregator must look for these same prefixes.